### PR TITLE
Create Iso3166Code.lutaml

### DIFF
--- a/models/datatypes/Iso3166Code.lutaml
+++ b/models/datatypes/Iso3166Code.lutaml
@@ -1,0 +1,5 @@
+data_type Iso3166Code {
+  definition {
+    Country and country subdivisions identifier, as defined in ISO 3166.
+  }
+}

--- a/views/DataTypes.lutaml
+++ b/views/DataTypes.lutaml
@@ -6,6 +6,7 @@ diagram DataTypes {
   include ../models/datatypes/Iso8601DateTime.lutaml
   include ../models/datatypes/Iso15924Code.lutaml
   include ../models/datatypes/Iso639Code.lutaml
+  include ../models/datatypes/Iso3166Code.lutaml
   include ../models/datatypes/StringFormat.lutaml
 
   association {


### PR DESCRIPTION
This type exists in StandardDocument under the BasicDocument namespace (cf.: https://github.com/metanorma/metanorma-model-standoc/blob/main/models/basic_document/datatypes/Iso3166Code.lutaml ), but doesn't exist here.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
